### PR TITLE
update xlnt to v1.0.0

### DIFF
--- a/ports/xlnt/CONTROL
+++ b/ports/xlnt/CONTROL
@@ -1,4 +1,4 @@
 Source: xlnt
-Version: 0.9.4
+Version: 1.0.0-1
 Description: Cross-platform user-friendly xlsx library for C++14
 Build-Depends: zlib, cryptopp, expat

--- a/ports/xlnt/portfile.cmake
+++ b/ports/xlnt/portfile.cmake
@@ -1,12 +1,12 @@
 include(vcpkg_common_functions)
 
-set(XLNT_REV 9dccde4bff34cfbafbdc3811fdd05326ac6bd0aa)
-set(XLNT_HASH 85bb651e42e33a829672ee76d14504fcbab683bb6b468d728837f1163b5ca1395c9aa80b3bed91a243e065599cdbf23cad769375f77792f71c173b02061771af)
-set(XLNT_SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xlnt-${XLNT_REV})
+set(XLNT_VERSION 1.0.0)
+set(XLNT_HASH f3d663cbe962c80ab684e677f1cc970aa1311d989f44a5d5d8311f93d69f4474b5bbd594796ad43a3b13d0a02bc040f877cad2979495a70a3a171ce94c20eae7)
+set(XLNT_SOURCE_PATH ${CURRENT_BUILDTREES_DIR}/src/xlnt-${XLNT_VERSION})
 
 vcpkg_download_distfile(ARCHIVE
-    URLS https://github.com/tfussell/xlnt/archive/${XLNT_REV}.zip
-    FILENAME xlnt-${XLNT_REV}.zip
+    URLS https://github.com/tfussell/xlnt/archive/v${XLNT_VERSION}.zip
+    FILENAME xlnt-${XLNT_VERSION}.zip
     SHA512 ${XLNT_HASH}
 )
 


### PR DESCRIPTION
minor changes to download the sources from github's release tab instead of git tree. Tested that can build x86-windows, x64-windows and x64-windows-static triplets.